### PR TITLE
Fix for invalid resource key in statement

### DIFF
--- a/aws/policy.tf
+++ b/aws/policy.tf
@@ -141,9 +141,9 @@ data "aws_iam_policy_document" "geopoiesis" {
   }
 
   statement {
-    effect   = "Allow"
-    actions  = ["sts:AssumeRole"]
-    resource = ["*"]
+    effect    = "Allow"
+    actions   = ["sts:AssumeRole"]
+    resources = ["*"]
   }
 
   # https://docs.aws.amazon.com/IAM/latest/UserGuide/list_xray.html


### PR DESCRIPTION
Error: module.geopoiesis-backend.data.aws_iam_policy_document.geopoiesis: statement.9: invalid or unknown key: resource

Looks to just be a typo.